### PR TITLE
Reword beam description, fix inconsistent British-ness, typos

### DIFF
--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/colored_wood_variants.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/colored_wood_variants.json
@@ -43,7 +43,7 @@
         "spectral-decorations:white_beam",
         "spectral-decorations:yellow_beam"
       ],
-      "text": "The bright colours of this new type of wood tug at that creative part of your mind. Mere logs and planks won't cut it for some buildings. No, they won't do! You've devised a way to make eye-catching support beams in any color you'd like."
+      "text": "The bright colours of this new type of wood tug at that creative part of your mind. Mere logs and planks won't cut it for some buildings. No, they won't do! You've devised a way to make eye-catching support beams in any colour you'd like."
     },
     {
       "type": "spectrum:pedestal_crafting",

--- a/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/colored_wood_variants.json
+++ b/src/main/resources/assets/spectrum/patchouli_books/guidebook/en_us/entries/decoration/colored_wood_variants.json
@@ -43,13 +43,13 @@
         "spectral-decorations:white_beam",
         "spectral-decorations:yellow_beam"
       ],
-      "text": "The bright colours of the wood spark a lot of creativity! A wide variety of decorative shapes and patterns some to mind that you can immediately use as enchantment to your buildings."
+      "text": "The bright colours of this new type of wood tug at that creative part of your mind. Mere logs and planks won't cut it for some buildings. No, they won't do! You've devised a way to make eye-catching support beams in any color you'd like."
     },
     {
       "type": "spectrum:pedestal_crafting",
       "title": "Colored Beams",
       "recipe": "spectral-decorations:beams/orange",
-      "text": "Come in all 16 colors."
+      "text": "Comes in all 16 colours."
     }
   ]
 }


### PR DESCRIPTION
Original beam description used both "color" and "colour." I'm not British, but I favor consistency. Fixed some typos, too.

If the colored wood beams unlock after pigment is collected, then it might make sense to add something to the part of base Spectrum's guidebook alluding to the player making colored beams before they find and unlock noxwood beams. I'm not sure how this would be implemented, so I'll just comment on that here.

If you don't like this rewording, I can submit a different PR with just typo fixes. =)

\- GD